### PR TITLE
Add SQLite database backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ python server.py
 ```
 
 The server listens on `http://localhost:5000` by default.
+By default data is stored in `inventory.db` in the current directory. You can
+specify a different location using the `DB_PATH` environment variable:
+
+```bash
+DB_PATH=/tmp/mydb.sqlite python server.py
+```
 
 ## API specification
 

--- a/controllers.py
+++ b/controllers.py
@@ -1,44 +1,41 @@
 from flask import jsonify, request, abort
 
-items = {}
-next_id = 1
+import database
 
 def ping():
     return jsonify({'message': 'pong'})
 
 def list_items():
-    return jsonify(list(items.values()))
+    return jsonify(database.list_items())
 
 def create_item():
     """Create a new item with a non-empty string name."""
-    global next_id
     data = request.get_json(force=True)
-    name = data.get('name') if isinstance(data, dict) else None
+    name = data.get("name") if isinstance(data, dict) else None
     if not isinstance(name, str) or not name.strip():
         abort(400)
-    item = {'id': next_id, 'name': name}
-    items[next_id] = item
-    next_id += 1
+    item = database.create_item(name)
     return jsonify(item), 201
 
 def get_item(id):
-    if id not in items:
+    item = database.get_item(id)
+    if item is None:
         abort(404)
-    return jsonify(items[id])
+    return jsonify(item)
 
 def update_item(id):
     """Update an existing item's name."""
-    if id not in items:
-        abort(404)
     data = request.get_json(force=True)
-    name = data.get('name') if isinstance(data, dict) else None
+    name = data.get("name") if isinstance(data, dict) else None
     if not isinstance(name, str) or not name.strip():
         abort(400)
-    items[id]['name'] = name
-    return jsonify(items[id])
+    item = database.update_item(id, name)
+    if item is None:
+        abort(404)
+    return jsonify(item)
 
 def delete_item(id):
-    if id not in items:
+    deleted = database.delete_item(id)
+    if deleted is None:
         abort(404)
-    deleted = items.pop(id)
     return jsonify(deleted)

--- a/database.py
+++ b/database.py
@@ -1,0 +1,78 @@
+import os
+import sqlite3
+
+_conn = None
+
+
+def get_db_path():
+    """Return path to SQLite DB from env or default."""
+    return os.environ.get('DB_PATH', 'inventory.db')
+
+
+def init_db(db_path: str | None = None):
+    """Initialize connection and ensure tables exist."""
+    global _conn
+    if db_path is None:
+        db_path = get_db_path()
+    _conn = sqlite3.connect(db_path, check_same_thread=False)
+    _conn.row_factory = sqlite3.Row
+    cursor = _conn.cursor()
+    cursor.execute(
+        "CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)"
+    )
+    _conn.commit()
+    return _conn
+
+
+def get_connection():
+    """Return initialized connection, creating one if needed."""
+    global _conn
+    if _conn is None:
+        init_db()
+    return _conn
+
+
+# CRUD helpers
+
+def list_items():
+    conn = get_connection()
+    cur = conn.execute("SELECT id, name FROM items ORDER BY id")
+    rows = cur.fetchall()
+    return [{"id": row["id"], "name": row["name"]} for row in rows]
+
+
+def create_item(name: str):
+    conn = get_connection()
+    cur = conn.execute("INSERT INTO items (name) VALUES (?)", (name,))
+    conn.commit()
+    item_id = cur.lastrowid
+    return {"id": item_id, "name": name}
+
+
+def get_item(item_id: int):
+    conn = get_connection()
+    cur = conn.execute("SELECT id, name FROM items WHERE id = ?", (item_id,))
+    row = cur.fetchone()
+    if row is None:
+        return None
+    return {"id": row["id"], "name": row["name"]}
+
+
+def update_item(item_id: int, name: str):
+    conn = get_connection()
+    cur = conn.execute("UPDATE items SET name = ? WHERE id = ?", (name, item_id))
+    if cur.rowcount == 0:
+        return None
+    conn.commit()
+    return {"id": item_id, "name": name}
+
+
+def delete_item(item_id: int):
+    conn = get_connection()
+    cur = conn.execute("SELECT id, name FROM items WHERE id = ?", (item_id,))
+    row = cur.fetchone()
+    if row is None:
+        return None
+    conn.execute("DELETE FROM items WHERE id = ?", (item_id,))
+    conn.commit()
+    return {"id": row["id"], "name": row["name"]}

--- a/server.py
+++ b/server.py
@@ -1,7 +1,10 @@
 import connexion
 
-app = connexion.App(__name__, specification_dir='.')
-app.add_api('api_spec.yaml')
+from database import init_db
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+app = connexion.App(__name__, specification_dir=".")
+app.add_api("api_spec.yaml")
+
+if __name__ == "__main__":
+    init_db()
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- add `database.py` with SQLite helpers
- initialize database connection in `server.py`
- use database operations in `controllers.py`
- document `DB_PATH` configuration in README

## Testing
- `pip install -r requirements.txt`
- `./run_e2e_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852ca0d878c8322ad90a12a10fbe194