### PR TITLE
Add name search query

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ python server.py
 
 The server listens on `http://localhost:5000` by default.
 
+Example search request:
+
+```bash
+curl http://localhost:5000/items?q=foo
+```
+
 ## API specification
 
 See [`api_spec.yaml`](api_spec.yaml) for the OpenAPI 3.0 specification of the available endpoints.

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -26,6 +26,12 @@ paths:
     get:
       summary: List all items
       operationId: controllers.list_items
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
+          description: Filter results by case-insensitive substring match on the item name. Returns all items when omitted.
       responses:
         '200':
           description: List of items

--- a/controllers.py
+++ b/controllers.py
@@ -7,7 +7,12 @@ def ping():
     return jsonify({'message': 'pong'})
 
 def list_items():
-    return jsonify(list(items.values()))
+    q = request.args.get('q')
+    results = list(items.values())
+    if q:
+        q_lower = q.lower()
+        results = [item for item in results if q_lower in item['name'].lower()]
+    return jsonify(results)
 
 def create_item():
     """Create a new item with a non-empty string name and integer quantity."""

--- a/run_e2e_tests.sh
+++ b/run_e2e_tests.sh
@@ -17,6 +17,10 @@ curl -fsS "$BASE_URL/ping" | grep -q 'pong'
 # Create item
 ITEM_ID=$(curl -fsS -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"test","quantity":5}' | jq '.id')
 
+# Search should find the new item
+curl -fsS "$BASE_URL/items?q=es" | jq -e "length == 1 and .[0].id == ${ITEM_ID}" >/dev/null
+curl -fsS "$BASE_URL/items?q=zzz" | jq -e 'length == 0' >/dev/null
+
 # Invalid creates
 check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"","quantity":1}'
 check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":123,"quantity":1}'
@@ -29,6 +33,7 @@ check_status 404 "$BASE_URL/items/9999"
 
 # Update item
 curl -fsS -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"updated","quantity":8}' | jq -e '.name == "updated" and .quantity == 8' >/dev/null
+curl -fsS "$BASE_URL/items?q=UPD" | jq -e "length == 1 and .[0].name == \"updated\"" >/dev/null
 check_status 400 -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"","quantity":1}'
 check_status 400 -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"updated","quantity":"foo"}'
 check_status 400 -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"updated","quantity":-5}'


### PR DESCRIPTION
## Summary
- implement optional `q` filter in `list_items`
- document `q` parameter in API spec
- show example search request in README
- test search functionality in e2e script

## Testing
- `./run_e2e_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852cf6d8e2c8322b0208ae8e45a6bba