### PR TITLE
Extend inventory items with price and low-stock route

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository provides a simple REST API written in Python using Flask. The AP
 
 The endpoint functions live in [`controllers.py`](controllers.py) and are referenced from `api_spec.yaml` via `operationId` definitions. The server uses [Connexion](https://connexion.readthedocs.io/) to load the OpenAPI specification and dispatch requests to these controller functions. Together they expose operations for creating, listing, updating and deleting inventory items.
 
+Each item consists of an integer `id`, a `name`, an integer `quantity` and a numeric `price` value.
+
 ## Requirements
 
 * Python 3.11+
@@ -42,6 +44,12 @@ Example search request:
 
 ```bash
 curl http://localhost:5000/items?q=foo
+```
+
+The `/items/low-stock` endpoint lists items whose quantity is below a provided threshold:
+
+```bash
+curl http://localhost:5000/items/low-stock?threshold=5
 ```
 
 ## API specification

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -57,6 +57,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Item'
+  /items/low-stock:
+    get:
+      summary: List items below a quantity threshold
+      operationId: controllers.low_stock
+      parameters:
+        - in: query
+          name: threshold
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Items with quantity below threshold
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Item'
   /items/{id}:
     get:
       summary: Get item by ID
@@ -122,7 +141,7 @@ components:
   schemas:
     Item:
       type: object
-      description: An inventory record identified by an integer ID, a name and a quantity.
+      description: An inventory record identified by an integer ID, a name, a quantity and a price.
       properties:
         id:
           type: integer
@@ -133,12 +152,16 @@ components:
         quantity:
           type: integer
           example: 10
+        price:
+          type: number
+          example: 9.99
     ItemInput:
       type: object
       description: Payload used when creating or updating an inventory item.
       required:
         - name
         - quantity
+        - price
       properties:
         name:
           type: string
@@ -146,3 +169,6 @@ components:
         quantity:
           type: integer
           example: 10
+        price:
+          type: number
+          example: 9.99

--- a/controllers.py
+++ b/controllers.py
@@ -15,16 +15,19 @@ def list_items():
     return jsonify(results)
 
 def create_item():
-    """Create a new item with a non-empty string name and integer quantity."""
+    """Create a new item with a non-empty string name, integer quantity and numeric price."""
     global next_id
     data = request.get_json(force=True)
     name = data.get('name') if isinstance(data, dict) else None
     quantity = data.get('quantity') if isinstance(data, dict) else None
+    price = data.get('price') if isinstance(data, dict) else None
     if not isinstance(name, str) or not name.strip():
         abort(400)
     if not isinstance(quantity, int) or quantity < 0:
         abort(400)
-    item = {'id': next_id, 'name': name, 'quantity': quantity}
+    if not (isinstance(price, int) or isinstance(price, float)) or price < 0:
+        abort(400)
+    item = {'id': next_id, 'name': name, 'quantity': quantity, 'price': price}
     items[next_id] = item
     next_id += 1
     return jsonify(item), 201
@@ -35,18 +38,22 @@ def get_item(id):
     return jsonify(items[id])
 
 def update_item(id):
-    """Update an existing item's name and quantity."""
+    """Update an existing item's name, quantity and price."""
     if id not in items:
         abort(404)
     data = request.get_json(force=True)
     name = data.get('name') if isinstance(data, dict) else None
     quantity = data.get('quantity') if isinstance(data, dict) else None
+    price = data.get('price') if isinstance(data, dict) else None
     if not isinstance(name, str) or not name.strip():
         abort(400)
     if not isinstance(quantity, int) or quantity < 0:
         abort(400)
+    if not (isinstance(price, int) or isinstance(price, float)) or price < 0:
+        abort(400)
     items[id]['name'] = name
     items[id]['quantity'] = quantity
+    items[id]['price'] = price
     return jsonify(items[id])
 
 def delete_item(id):
@@ -54,3 +61,11 @@ def delete_item(id):
         abort(404)
     deleted = items.pop(id)
     return jsonify(deleted)
+
+def low_stock():
+    """List items with quantity below the given threshold."""
+    threshold = request.args.get('threshold', type=int)
+    if threshold is None or threshold < 0:
+        abort(400)
+    results = [item for item in items.values() if item['quantity'] < threshold]
+    return jsonify(results)

--- a/run_e2e_tests.sh
+++ b/run_e2e_tests.sh
@@ -15,29 +15,34 @@ check_status() {
 curl -fsS "$BASE_URL/ping" | grep -q 'pong'
 
 # Create item
-ITEM_ID=$(curl -fsS -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"test","quantity":5}' | jq '.id')
+ITEM_ID=$(curl -fsS -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"test","quantity":5,"price":1.5}' | jq '.id')
 
 # Search should find the new item
 curl -fsS "$BASE_URL/items?q=es" | jq -e "length == 1 and .[0].id == ${ITEM_ID}" >/dev/null
 curl -fsS "$BASE_URL/items?q=zzz" | jq -e 'length == 0' >/dev/null
 
+# Low-stock query
+curl -fsS "$BASE_URL/items/low-stock?threshold=6" | jq -e "length == 1 and .[0].id == ${ITEM_ID}" >/dev/null
+check_status 400 "$BASE_URL/items/low-stock?threshold=-1"
+
 # Invalid creates
-check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"","quantity":1}'
-check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":123,"quantity":1}'
-check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"bad","quantity":"foo"}'
-check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"bad","quantity":-1}'
+check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"","quantity":1,"price":1}'
+check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":123,"quantity":1,"price":1}'
+check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"bad","quantity":"foo","price":1}'
+check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"bad","quantity":-1,"price":1}'
+check_status 400 -X POST "$BASE_URL/items" -H 'Content-Type: application/json' -d '{"name":"bad","quantity":1}'
 
 # Get item
-curl -fsS "$BASE_URL/items/${ITEM_ID}" | jq -e '.name == "test" and .quantity == 5' >/dev/null
+curl -fsS "$BASE_URL/items/${ITEM_ID}" | jq -e '.name == "test" and .quantity == 5 and .price == 1.5' >/dev/null
 check_status 404 "$BASE_URL/items/9999"
 
 # Update item
-curl -fsS -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"updated","quantity":8}' | jq -e '.name == "updated" and .quantity == 8' >/dev/null
+curl -fsS -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"updated","quantity":8,"price":2.0}' | jq -e '.name == "updated" and .quantity == 8 and .price == 2.0' >/dev/null
 curl -fsS "$BASE_URL/items?q=UPD" | jq -e "length == 1 and .[0].name == \"updated\"" >/dev/null
-check_status 400 -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"","quantity":1}'
-check_status 400 -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"updated","quantity":"foo"}'
-check_status 400 -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"updated","quantity":-5}'
-check_status 404 -X PUT "$BASE_URL/items/9999" -H 'Content-Type: application/json' -d '{"name":"foo","quantity":1}'
+check_status 400 -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"","quantity":1,"price":1}'
+check_status 400 -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"updated","quantity":"foo","price":1}'
+check_status 400 -X PUT "$BASE_URL/items/${ITEM_ID}" -H 'Content-Type: application/json' -d '{"name":"updated","quantity":-5,"price":1}'
+check_status 404 -X PUT "$BASE_URL/items/9999" -H 'Content-Type: application/json' -d '{"name":"foo","quantity":1,"price":1}'
 
 # Delete item
 curl -fsS -X DELETE "$BASE_URL/items/${ITEM_ID}" | jq -e ".id == ${ITEM_ID}" >/dev/null


### PR DESCRIPTION
## Summary
- add numeric `price` field to items
- validate new field in controller create and update functions
- expose `/items/low-stock` endpoint via spec and controller
- document new field and endpoint in README
- update e2e tests for price handling and new route

## Testing
- `pip install -r requirements.txt`
- `python server.py &`
- `./run_e2e_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852d08b65748322a226e4777397a490