### PR TITLE
Improve documentation and add port support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The endpoint functions live in [`controllers.py`](controllers.py) and are refere
 
 Each item consists of an integer `id`, a `name`, an integer `quantity` and a numeric `price` value.
 
+The server also exposes a simple health check at `GET /ping` which returns
+`{"message": "pong"}`.
+
 ## Requirements
 
 * Python 3.11+
@@ -24,7 +27,8 @@ pip install -r requirements.txt
 python server.py
 ```
 
-The server listens on `http://localhost:5000` by default.
+Set the `PORT` environment variable to change the listen port (default `5000`).
+The E2E script respects this value when computing its default `BASE_URL`.
 
 ## Docker
 
@@ -56,10 +60,20 @@ curl http://localhost:5000/items/low-stock?threshold=5
 
 See [`api_spec.yaml`](api_spec.yaml) for the OpenAPI 3.0 specification of the available endpoints.
 
+## Unit tests
+
+Run the automated unit tests using [pytest](https://docs.pytest.org/en/stable/):
+
+```bash
+pytest -q
+```
+
 ## End‑to‑end tests
 
-Run the provided script after starting the server. The suite now exercises
-common error scenarios such as invalid input and unknown IDs:
+Run the provided script after starting the server. The suite exercises common
+error scenarios such as invalid input and unknown IDs. The script assumes the
+server is reachable at `http://localhost:${PORT}` but you can override this by
+setting the `BASE_URL` environment variable:
 
 ```bash
 ./run_e2e_tests.sh

--- a/run_e2e_tests.sh
+++ b/run_e2e_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
-BASE_URL=${BASE_URL:-http://localhost:5000}
+PORT=${PORT:-5000}
+BASE_URL=${BASE_URL:-http://localhost:${PORT}}
 
 check_status() {
   expected=$1; shift

--- a/server.py
+++ b/server.py
@@ -1,7 +1,9 @@
+import os
 import connexion
 
 app = connexion.App(__name__, specification_dir='.')
 app.add_api('api_spec.yaml')
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- clarify README with health check info, port env var and testing instructions
- support configurable port via `PORT` env variable
- sync e2e script with PORT variable

## Testing
- `pytest -q`
- `./run_e2e_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852d2e760488322bd190f2218060e36